### PR TITLE
Improve the performance of finding empty lines

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,6 +50,8 @@ class EnsureSingleFinalNewlineHandler {
                     } else {
                         break;
                     }
+                } else {
+                    break;
                 }
             }
 


### PR DESCRIPTION
Stop finding empty line and leave the for-loop soon if the final line is not empty or whitespace. It can improve the performance when the file is large.
