### PR TITLE
Change primary config to `files.ensureSingleFinalNewline`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Launch VS Code Quick Open (Ctrl+P), paste the following command, and press enter
 ext install vscode-ensure-single-final-newline
 ```
 
-## Usage
+## Extension Settings
 
-Enable or disable by setting `files.insertFinalNewline` in VS Code configuration.
+Enable or disable by setting `files.ensureSingleFinalNewline` in VS Code configuration.
 
 ```json
 {
-  "files.insertFinalNewline": true
+  "files.ensureSingleFinalNewline": true
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,19 @@
   "activationEvents": [
     "*"
   ],
+  "contributes": {
+    "configuration": {
+      "type": "object",
+      "title": "Ensure Single Final Newline",
+      "properties": {
+        "files.ensureSingleFinalNewline": {
+          "type": "boolean",
+          "default": true,
+          "description": "Controls whether just one single newline is appended to the file when you save it."
+        }
+      }
+    }
+  },
   "main": "./out/src/extension",
   "scripts": {
     "vscode:prepublish": "tsc -p ./",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@
 import {
     Disposable,
     ExtensionContext,
+    Position,
     Range,
     TextDocumentWillSaveEvent,
     TextEdit,
@@ -37,7 +38,7 @@ class EnsureSingleFinalNewlineHandler {
     }
 
     private _onWillSaveTextDocument(event: TextDocumentWillSaveEvent) {
-        if (this._config.get('insertFinalNewline', false)) {
+        if (this._config.get('ensureSingleFinalNewline', false)) {
             const doc = event.document;
             const edits = [];
 
@@ -52,6 +53,15 @@ class EnsureSingleFinalNewlineHandler {
                     }
                 } else {
                     break;
+                }
+            }
+
+            if (!this._config.get('insertFinalNewline', false)) {
+                const lastLineIndex = doc.lineCount - 1;
+                const lastLine = doc.lineAt(lastLineIndex);
+                if (!lastLine.isEmptyOrWhitespace) {
+                    const eol = this._config.get('eol', '\n');
+                    edits.push(TextEdit.insert(new Position(lastLineIndex, lastLine.text.length), eol));
                 }
             }
 

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -7,28 +7,43 @@ import {create, EOL} from './helpers';
 suite('Ensure Single Final Newline', () => {
     suiteTeardown(utils.closeAllFiles);
 
-    test('Insert final newline', async () => {
-        const document = await create(true);
+    test('Inserts a final newline when the file does not have one', async () => {
+        const document = await create(true, true);
         assert.strictEqual(await document.saveText('FooBar'), `FooBar${EOL}`);
     });
 
-    test('Do not insert final newline', async () => {
-        const document = await create(false);
-        assert.strictEqual(await document.saveText('FooBar'), 'FooBar');
+    test('Does not insert newline when the file ends with one newline.', async () => {
+        const document = await create(true, true);
+        assert.strictEqual(await document.saveText(`FooBar${EOL}`), `FooBar${EOL}`);
     });
 
-    test('Remove final newlines but keep only one', async () => {
-        const document = await create(true);
+    test('Removes extra newlines at the end of the file', async () => {
+        const document = await create(true, true);
         assert.strictEqual(await document.saveText(`FooBar${EOL}${EOL}`), `FooBar${EOL}`);
     });
 
-    test('Do not remove final newlines', async () => {
-        const document = await create(false);
+    test('Do not removes extra newlines when `files.ensureSingleFinalNewline` is false', async () => {
+        const document = await create(false, true);
         assert.strictEqual(await document.saveText(`FooBar${EOL}${EOL}`), `FooBar${EOL}${EOL}`);
     });
 
-    test('Do not remove empty lines', async () => {
-        const document = await create(true);
-        assert.strictEqual(await document.saveText(`Foo${EOL}${EOL}Bar${EOL}${EOL}`), `Foo${EOL}${EOL}Bar${EOL}`);
+    test('Inserts a newline at the end of the file even `files.insertFinalNewline` is false', async () => {
+        const document = await create(true, false);
+        assert.strictEqual(await document.saveText(`FooBar`), `FooBar${EOL}`);
+    });
+
+    test('Removes extra newlines at the end of the file even `files.insertFinalNewline` is false', async () => {
+        const document = await create(true, false);
+        assert.strictEqual(await document.saveText(`FooBar${EOL}${EOL}`), `FooBar${EOL}`);
+    });
+
+    test('Inserts a final newline as long as `files.insertFinalNewline` is true', async () => {
+        const document = await create(false, true);
+        assert.strictEqual(await document.saveText('FooBar'), `FooBar${EOL}`);
+    });
+
+    test('Does not insert a final newline when both `files.insertFinalNewline` and `files.ensureSingleFinalNewline` are false', async () => {
+        const document = await create(false, false);
+        assert.strictEqual(await document.saveText('FooBar'), 'FooBar');
     });
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -5,12 +5,17 @@ import * as utils from 'vscode-test-utils';
 import * as assert from 'assert';
 import * as tempfile from 'tempfile';
 
-export function create(insertFinalNewline: boolean = true, file: string = tempfile('.txt')) {
+export function create(
+    ensureSingleFinalNewline: boolean = true,
+    insertFinalNewline: boolean = true,
+    file: string = tempfile('.txt')
+) {
     async function createDocument(filepath: string, content: string = '') {
         const filename = await utils.createFile(content, filepath);
         const document = await vscode.workspace.openTextDocument(filename);
         const config = vscode.workspace.getConfiguration('files');
 
+        await config.update('ensureSingleFinalNewline', ensureSingleFinalNewline, true);
         await config.update('insertFinalNewline', insertFinalNewline, true);
         await vscode.window.showTextDocument(document);
 


### PR DESCRIPTION
As mentioned in #1. Using `files.ensureSingleFinalNewline` as primary configuration is more logical. So this PR adds `files.ensureSingleFinalNewline` to user configuration.

This is a breaking change so when it merged, the next version should be a major update (x.y.z -> x+1.0.0).
